### PR TITLE
DPI-29029 Package rhtmlMoonPlot in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "rhtmlMoonPlot";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''An opinionated template for the creation of html widget repositories using ES6'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    htmlwidgets
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package rhtmlMoonPlot in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR